### PR TITLE
fixed namespace issue in geminiimageanalysis

### DIFF
--- a/Rest_SikkerApi/Rest_SikkerApi/Services/GeminiImageAnalysisService.cs
+++ b/Rest_SikkerApi/Rest_SikkerApi/Services/GeminiImageAnalysisService.cs
@@ -1,6 +1,5 @@
 using System.Text;
 using System.Text.Json;
-using Rest_SikkerApi.Models;
 using Rest_SikkerApi.models;
 using Rest_SikkerApi.data;
 using Rest_SikkerApi.repos;

--- a/Rest_SikkerApi/Rest_SikkerApi/Services/IImageAnalysisService.cs
+++ b/Rest_SikkerApi/Rest_SikkerApi/Services/IImageAnalysisService.cs
@@ -1,4 +1,4 @@
-﻿using Rest_SikkerApi.Models;
+﻿using Rest_SikkerApi.models;
 
 namespace Rest_SikkerApi.Services;
 

--- a/Rest_SikkerApi/Rest_SikkerApi/models/ImageAnalysisResult.cs
+++ b/Rest_SikkerApi/Rest_SikkerApi/models/ImageAnalysisResult.cs
@@ -1,4 +1,4 @@
-﻿namespace Rest_SikkerApi.Models;
+﻿namespace Rest_SikkerApi.models;
 
 public sealed class ImageAnalysisResult
 {


### PR DESCRIPTION
fixed a namespace issue, causeing us to need both .models and .Models in GeminiImageAnalysisService.cs